### PR TITLE
Add support for Python3.12

### DIFF
--- a/arbitragelab/ml_approach/optics_dbscan_pairs_clustering.py
+++ b/arbitragelab/ml_approach/optics_dbscan_pairs_clustering.py
@@ -327,7 +327,7 @@ class OPTICSDBSCANPairsClustering:
 
             for combination in list(itertools.combinations(cluster_x, 2)):
                 pair_combinations.append(combination)
-
+        
         return pair_combinations
 
     @staticmethod

--- a/arbitragelab/ml_approach/optics_dbscan_pairs_clustering.py
+++ b/arbitragelab/ml_approach/optics_dbscan_pairs_clustering.py
@@ -167,7 +167,7 @@ class OPTICSDBSCANPairsClustering:
 
         fig = plt.figure(facecolor='white', figsize=figsize)
 
-        tsne = TSNE(n_components=n_dimensions)
+        tsne = TSNE(n_components=n_dimensions, init="random")
 
         tsne_fv = pd.DataFrame(tsne.fit_transform(self.feature_vector),
                                index=self.feature_vector.index)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,8 @@ Changelog
     * :feature:`50` Add a distutils command for marbles
     * :bug:`58` Fixed test failure on OSX
 
+* :support:`93` Upgrade packages to support Python 3.12 and below
+
 * :release:`0.9.1 <2024-01-10>`
 * :bug:`92` Released a new version because of pypi version was wrong
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
 # Production
-POT==0.9.0
+POT==0.9.1
 arch==5.5.0
-cvxpy==1.3.1
+cvxpy>=1.3.1, <=1.4.3
 cython==0.29.28
 dash==2.10.2
 jupyter-dash>=0.2.0, <1.0.0
-keras==2.12.0
+keras>=2.12.0, <=3.2.1
 lxml>=4.9.1
 matplotlib==3.7.1
 mpmath==1.2.1
 networkx>=2.2, <2.6
-numpy==1.23.5
+numpy >=1.23.5, <=1.26.4
 pandas==2.0.0
-pmdarima==2.0.3
+pmdarima==2.0.4
 protobuf>=3.20.3
-pyvinecopulib==0.5.5
+pyvinecopulib>=0.5.5, <=0.6.5
 requests_html==0.10.0
-scikit-learn==1.1.3
-scipy>=1.2.0, <2.0.0
-scs==3.2.0
+scikit-learn>=1.1.3, <=1.2.2
+scipy>=1.2.0, <=1.11.4
+scs>=3.2.0, <=3.2.4
 seaborn==0.12.2
 statsmodels==0.14.0
-tensorflow-macos==2.12.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos>=2.12.0, <=2.16.1; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow>=2.12.0, <=2.16.1; sys_platform != 'darwin' or platform_machine != 'arm64'
 werkzeug==2.2.3
 yahoo-fin==0.8.9.1
-yfinance==0.2.24
+yfinance>=0.2.24, <=0.2.38
 
 # Develop
 coverage==7.2.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,37 +39,37 @@ keywords =
 include_package_data = True
 packages = find:
 python_requires =
-    ~=3.8
+    <=3.12
 setup_requires =
     setuptools
 install_requires =
     POT==0.9.1
     arch==5.5.0
-    cvxpy==1.3.1
+    cvxpy>=1.3.1, <=1.4.3
     cython==0.29.28
     dash==2.10.2
     jupyter-dash>=0.2.0, <1.0.0
-    keras==2.12.0
+    keras>=2.12.0, <=3.2.1
     lxml>=4.9.1
     matplotlib==3.7.1
     mpmath==1.2.1
     networkx>=2.2, <2.6
-    numpy==1.23.5
+    numpy >=1.23.5, <=1.26.4
     pandas==2.0.0
-    pmdarima==2.0.3
+    pmdarima==2.0.4
     protobuf>=3.20.3
-    pyvinecopulib==0.5.5
+    pyvinecopulib>=0.5.5, <=0.6.5
     requests_html==0.10.0
-    scikit-learn==1.1.3
-    scipy>=1.2.0, <2.0.0
-    scs==3.2.0
+    scikit-learn>=1.1.3, <=1.2.2
+    scipy>=1.2.0, <=1.11.4
+    scs>=3.2.0, <=3.2.4
     seaborn==0.12.2
     statsmodels==0.14.0
-    tensorflow-macos==2.12.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-    tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+    tensorflow-macos>=2.12.0, <=2.16.1; sys_platform == 'darwin' and platform_machine == 'arm64'
+    tensorflow>=2.12.0, <=2.16.1; sys_platform != 'darwin' or platform_machine != 'arm64'
     werkzeug==2.2.3
     yahoo-fin==0.8.9.1
-    yfinance==0.2.24
+    yfinance>=0.2.24, <=0.2.38
 
 [options.packages.find]
 package_dir =

--- a/tests/test_neural_networks.py
+++ b/tests/test_neural_networks.py
@@ -5,8 +5,9 @@ Tests Spread Modeling Neural Network Classes.
 import unittest
 import numpy as np
 import tensorflow as tf
-from keras.engine.training import Model
+from keras import Model
 from keras.callbacks import History
+from tensorflow.python.keras import backend as K
 from sklearn.model_selection import train_test_split
 from sklearn.datasets import make_regression
 
@@ -31,7 +32,7 @@ class TestNeuralNetworks(unittest.TestCase):
 
         session_conf = tf.compat.v1.ConfigProto(intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
         sess = tf.compat.v1.Session(graph=tf.compat.v1.get_default_graph(), config=session_conf)
-        tf.compat.v1.keras.backend.set_session(sess)
+        K.set_session(sess)
 
         self.seed_value = seed_value
 

--- a/tests/test_optics_dbscan_pairs_clustering.py
+++ b/tests/test_optics_dbscan_pairs_clustering.py
@@ -99,6 +99,9 @@ class TestDBSCANClustering(unittest.TestCase):
         self.assertEqual(len(c_labels), 15)
 
         # Check number of pairwise combinations using cluster data.
+        a = np.array(init_labels)
+        print(len(a[a==-1]))
+        print([len(a[a == i]) for i in c_labels])
         pair_list = self.pair_selector._generate_pairwise_combinations(c_labels)
         self.assertEqual(len(pair_list), 158)
 

--- a/tests/test_optics_dbscan_pairs_clustering.py
+++ b/tests/test_optics_dbscan_pairs_clustering.py
@@ -99,9 +99,6 @@ class TestDBSCANClustering(unittest.TestCase):
         self.assertEqual(len(c_labels), 15)
 
         # Check number of pairwise combinations using cluster data.
-        a = np.array(init_labels)
-        print(len(a[a==-1]))
-        print([len(a[a == i]) for i in c_labels])
         pair_list = self.pair_selector._generate_pairwise_combinations(c_labels)
         self.assertEqual(len(pair_list), 158)
 

--- a/tests/test_spread_modeling_helper.py
+++ b/tests/test_spread_modeling_helper.py
@@ -6,6 +6,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import tensorflow as tf
+from tensorflow.python.keras import backend as K
 
 from arbitragelab.cointegration_approach.johansen import JohansenPortfolio
 from arbitragelab.ml_approach.regressor_committee import RegressorCommittee
@@ -28,7 +29,7 @@ class TestSpreadModelingHelper(unittest.TestCase):
 
         session_conf = tf.compat.v1.ConfigProto(intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
         sess = tf.compat.v1.Session(graph=tf.compat.v1.get_default_graph(), config=session_conf)
-        tf.compat.v1.keras.backend.set_session(sess)
+        K.set_session(sess)
 
         # Collect all contract price data.
         project_path = os.path.dirname(__file__)

--- a/tests/test_trading_copula_strategy_mpi.py
+++ b/tests/test_trading_copula_strategy_mpi.py
@@ -319,10 +319,15 @@ class TestMPICopulaTradingRule(unittest.TestCase):
             results_2.append(CS._get_position_and_reset_flag(
                 pre_flag=pre_flag, raw_cur_flag=raw_cur_flags[i], open_rule='or', exit_rule='and',
                 pre_position=pre_positions[i], open_based_on=open_based_ons_2[i]))
+            
+        # Numpy doesnt like inhomogeneous arrays in numpy > 1.21.6. Fix for this is to make an array of objects    
         # Expected results, (cur_position, if_reset_flag, open_based_on)
-        expected = [(1, False, [1, 2]), (1, False, [1, 1]), (-1, False, [-1, 1]), (-1, False, [-1, 2]),
+        expected = np.asarray([(1, False, [1, 2]), (1, False, [1, 1]), (-1, False, [-1, 1]), (-1, False, [-1, 2]),
                     (-1, False, [-1, 2]), (-1, False, [-1, 1]), (1, False, [1, 2]), (1, False, [1, 1]),
-                    (-1, False, [-1, 1]), (-1, False, [-1, 1])]
+                    (-1, False, [-1, 1]), (-1, False, [-1, 1])], dtype="object")
+        
+        results_1 = np.asarray(results_1, dtype="object")
+        results_2 = np.asarray(results_2, dtype="object")
         # Check matching with expecteation
         np.testing.assert_array_equal(results_1, expected)
         # Check results are indep of open_based_on conditions
@@ -481,10 +486,15 @@ class TestMPICopulaTradingRule(unittest.TestCase):
             results_2.append(CS._get_position_and_reset_flag(
                 pre_flag=pre_flag, raw_cur_flag=raw_cur_flags[i], open_rule='and', exit_rule='or',
                 pre_position=pre_positions[i], open_based_on=open_based_ons_2[i]))
+        
+        # Numpy doesnt like inhomogeneous arrays in numpy > 1.21.6. Fix for this is to make an array of objects
         # Expected results, (cur_position, if_reset_flag, open_based_on)
-        expected = [(0, False, [1, 2]), (0, False, [1, 1]), (0, False, [-1, 1]), (0, False, [-1, 2]),
+        expected = np.asarray([(0, False, [1, 2]), (0, False, [1, 1]), (0, False, [-1, 1]), (0, False, [-1, 2]),
                     (1, False, [-1, 2]), (1, False, [-1, 1]), (-1, False, [1, 2]), (-1, False, [1, 1]),
-                    (0, True, [0, 0]), (0, True, [0, 0]), (-1, False, [-1, 2])]
+                    (0, True, [0, 0]), (0, True, [0, 0]), (-1, False, [-1, 2])], dtype="object")
+
+        results_1 = np.asarray(results_1, dtype="object")
+        results_2 = np.asarray(results_2, dtype="object")        
         # Check matching with expecteation
         np.testing.assert_array_equal(results_1, expected)
         # Check results are indep of open_based_on conditions
@@ -646,10 +656,15 @@ class TestMPICopulaTradingRule(unittest.TestCase):
                 pre_flag=pre_flag, raw_cur_flag=raw_cur_flags[i], open_rule='and', exit_rule='and',
                 pre_position=pre_positions[i], open_based_on=open_based_ons_2[i]))
 
+        # Numpy doesnt like inhomogeneous arrays in numpy > 1.21.6. Fix for this is to make an array of objects
         # Expected results, (cur_position, if_reset_flag, open_based_on)
-        expected = [(0, False, [1, 2]), (0, False, [1, 1]), (0, False, [-1, 1]), (0, False, [-1, 2]),
+        expected = np.asarray([(0, False, [1, 2]), (0, False, [1, 1]), (0, False, [-1, 1]), (0, False, [-1, 2]),
                     (1, False, [-1, 2]), (1, False, [-1, 1]), (-1, False, [1, 2]), (-1, False, [1, 1]),
-                    (-1, False, [-1, 1]), (-1, False, [-1, 1]), (-1, False, [-1, 2])]
+                    (-1, False, [-1, 1]), (-1, False, [-1, 1]), (-1, False, [-1, 2])], dtype="object")
+        
+        results_1 = np.asarray(results_1, dtype="object")
+        results_2 = np.asarray(results_2, dtype="object")
+        
         # Check matching with expecteation
         np.testing.assert_array_equal(results_1, expected)
         # Check results are indep of open_based_on conditions


### PR DESCRIPTION
## Purpose
The purpose of this pull request is to update dependencies such that the package can be installed on python 3.12. With the changes in setuptools introduced py3.12 cannot build wheels for some earlier packages. The changes in this PR address this issue as well as add a slight modification to the TSNE object in optics_dbscan_pairs_clustering.py since it uses a deprecated default argument. The argument (init="random") is explicitly provided instead of using the default parameter as this breaks the tests on newer versions of sklearn (init="pca" and current tests run into similar issues as described [here](https://stackoverflow.com/questions/56694980/valueerror-n-components-4-must-be-between-0-and-minn-samples-n-features-2-wi))

## Approach
Packages were updated to versions usable in py3.12. Tests were run to insure no breaking changes occurred. Packages were bounded. 

Import of keras backend was updated.



## Tests for New Behavior
Pytest was run

## Checklist
_Make sure you did the following (if applicable):_
- [x] Added tests for any new features or behaviors.
- [x] Ran ``./pylint`` to make sure code style is consistent.
Pylint was run but changes are from original main branch. Should address this (such as imports) in other prs

- [x] Built and reviewed the docs.
- [x] Added a note to the [changelog](https://github.com/hudson-and-thames/arbitragelab/blob/develop/docs/source/changelog.rst).

## Learning

